### PR TITLE
Show used letters in Wordle clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # wordle-fasthtml
+
+Simple Wordle clone built with FastHTML. The interface now displays a small
+keyboard showing which letters you've already guessed.

--- a/main.py
+++ b/main.py
@@ -60,6 +60,13 @@ css = Style(f'''
     .letter-box.gray {{ background-color: #787c7e; border-color: #787c7e; color: white; }}
     .letter-box.yellow {{ background-color: #c9b458; border-color: #c9b458; color: white; }}
     .letter-box.green {{ background-color: #6aaa64; border-color: #6aaa64; color: white; }}
+    .letter-box.small {{
+        width: 30px; height: 30px;
+        font-size: 1rem;
+    }}
+    .used-letters {{
+        display: flex; flex-wrap: wrap; gap: 4px; justify-content: center;
+    }}
 
     .input-area form {{ display: flex; gap: 10px; margin-bottom: 10px; }}
     .input-area input[type="text"] {{
@@ -128,6 +135,17 @@ def evaluate_guess(guess: str, target: str) -> list[str]:
                 result[i] = "gray"
     return result
 
+def get_used_letter_colors() -> dict[str, str]:
+    """Return a mapping of guessed letters to their best achieved color."""
+    priority = {"gray": 0, "yellow": 1, "green": 2}
+    colors: dict[str, str] = {}
+    for guess, result in zip(game_state['guesses'], game_state['results']):
+        for ch, col in zip(guess, result):
+            prev = colors.get(ch)
+            if prev is None or priority[col] > priority[prev]:
+                colors[ch] = col
+    return colors
+
 # --- UI Components ---
 def UIGuessGrid():
     rows = []
@@ -165,6 +183,14 @@ def UIInputArea():
 def UIMessageArea():
     return Div(game_state['message'], id='message-area', cls='message-area')
 
+def UIUsedLetters():
+    colors = get_used_letter_colors()
+    boxes = []
+    for ch in 'abcdefghijklmnopqrstuvwxyz':
+        color = colors.get(ch, 'empty')
+        boxes.append(Div(ch.upper(), cls=f'letter-box small {color}'))
+    return Div(*boxes, id='used-letters', cls='used-letters')
+
 def UIControls():
     return Div(
         Form(
@@ -178,6 +204,7 @@ def UIControls():
 def WordleGameArea():
     return Div(
         UIGuessGrid(),
+        UIUsedLetters(),
         UIMessageArea(),
         UIInputArea(),
         UIControls(),

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -38,3 +38,17 @@ def test_reset_game_state_sets_new_word_and_clears_guesses():
     assert main.game_state['target_word'] == 'abcde'
     assert main.game_state['guesses'] == []
     assert main.game_state['results'] == []
+
+
+def test_get_used_letter_colors_prioritizes_colors():
+    main.game_state['guesses'] = ['abcde', 'fghij']
+    main.game_state['results'] = [
+        ['gray', 'yellow', 'green', 'gray', 'gray'],
+        ['yellow', 'green', 'gray', 'gray', 'gray'],
+    ]
+    colors = main.get_used_letter_colors()
+    assert colors['a'] == 'gray'
+    assert colors['b'] == 'yellow'
+    assert colors['c'] == 'green'
+    assert colors['f'] == 'yellow'
+    assert colors['g'] == 'green'


### PR DESCRIPTION
## Summary
- display alphabet letter bank with their best result color
- add helper to compute used letters from guesses
- update README
- test the helper logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fasthtml')*

------
https://chatgpt.com/codex/tasks/task_b_68418d7ee4908331b60aa7abb0a318e0